### PR TITLE
fixed room indexing by checking string length after last hyphen(-)

### DIFF
--- a/src/app/api/snutt/free-rooms/route.ts
+++ b/src/app/api/snutt/free-rooms/route.ts
@@ -54,10 +54,39 @@ function splitPlaces(p: string): string[] {
     .filter(Boolean);
 }
 
-/** 방 이름만: "301-118" → "118", "301-B119" → "B119" */
-function roomLabel(room: string): string {
-  const idx = room.indexOf("-");
-  return idx >= 0 ? room.slice(idx + 1) : room;
+/** 방 이름만: "301-118" → "118", "301-B119" → "B119", 
+ * "71-1-101" -> "101", "301-113-2" -> "113-2"*/
+function parsePlace(place: string): { building: string; room: string } | null {
+  const lastDashIndex = place.lastIndexOf("-");
+  const partAfterLastDash = place.substring(lastDashIndex + 1);
+
+  let splitIndex = lastDashIndex;
+
+  if (partAfterLastDash.length === 1) {
+    const secondLastDashIndex = place.lastIndexOf("-", lastDashIndex - 1);
+    
+    if (secondLastDashIndex !== -1) {
+      splitIndex = secondLastDashIndex;
+    }
+  }
+
+  const building = place.substring(0, splitIndex);
+  const room = place.substring(splitIndex + 1);
+
+  if (!building || !room) return null; // not parsed
+  return { building, room };
+}
+
+
+/** 호실 번호만 추출: "301-113-2" → "113-2", "71-1-101" → "101" */
+function roomLabel(place: string): string {
+  const parsed = parsePlace(place);
+  if (parsed) {
+    return parsed.room;
+  }
+  // if not parsed
+  const idx = place.lastIndexOf("-");
+  return idx >= 0 ? place.slice(idx + 1) : place;
 }
 
 /** GET /api/snutt/free-rooms?year=2025&semester=3&building=301&day=0&at=13:40 */


### PR DESCRIPTION
동 번호 및 호실 번호에 모두 hyphen이 존재할 수 있어,
호실 번호를 추출하는 과정에서 생긴 오류를 마지막 "-" 이후의 string length를 확인함으로써 해결함

Old:   "71-1-101" -> "1-101", "301-113-2" -> "113-2"
Fixed: "71-1-101" -> "101",    "301-113-2" -> "113-2"